### PR TITLE
Fix for latest connection problems in FF 47

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
   matrix:
     - FirefoxVersion=31.8.0esr
     - FirefoxVersion=38.2.1esr
-    - FirefoxVersion=40.0
-    - FirefoxVersion=44.0
+    - FirefoxVersion=45.0.2esr
+    - FirefoxVersion=47.0.1
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Synoloader",
-  "version": "2.0.0",
+  "version": "2.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/Lemutar/Synoloader.git"

--- a/src/chrome/content/ff-overlay.js
+++ b/src/chrome/content/ff-overlay.js
@@ -6,19 +6,6 @@ if (typeof SL_Overlay === "undefined") {
     var SL_Overlay = {};
 
     (function() {
-        this.firstRun = (extensions) => {
-            let firstRunPref = "extensions.SynoLoader.firstRunDone";
-
-            if (!Application.prefs.getValue(firstRunPref, false)) {
-                Application.prefs.setValue(firstRunPref, true);
-
-                let toolbar = document.getElementById("nav-bar");
-                toolbar.insertItem("sl-toolbar", null);
-                toolbar.setAttribute("currentset", toolbar.currentSet);
-                document.persist(toolbar.id, "currentset");
-            }
-        };
-
         this.updateListPanel = () => {
             let panel = document.getElementById("sl-toolbar-panel"),
                 label = document.getElementById("sl-toolbar-panel-label"),
@@ -69,11 +56,6 @@ if (typeof SL_Overlay === "undefined") {
 
         this.onLoad = () => {
             Util.log("SL_Overlay loaded");
-            if (Application.extensions) {
-                this.firstRun(Application.extensions);
-            } else {
-                Application.getExtensions(this.firstRun);
-            }
 
             document.getElementById("contentAreaContextMenu")
                 .addEventListener("popupshowing", (event) => {

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -3,7 +3,7 @@
   <Description about="urn:mozilla:install-manifest">
     <em:id>lemutar@gmail.com</em:id>
     <em:type>2</em:type>
-    <em:version>2.2.0</em:version>
+    <em:version>2.2.1</em:version>
     <em:creator>Lemutar</em:creator>
     <em:unpack>true</em:unpack>
     <em:localized>
@@ -21,7 +21,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!-- Firefox -->
   			<em:minVersion>31.0</em:minVersion>
-  			<em:maxVersion>44.0</em:maxVersion>
+  			<em:maxVersion>47.0.1</em:maxVersion>
       </Description>
     </em:targetApplication>
   </Description>


### PR DESCRIPTION
Remove firstRun code, since it fails and isn't really necessary. (User will need to add the toolbar button manually when installing the extension freshly)
Update version numbers to 2.2.1
Update version to test with travis.

Fixes #38 